### PR TITLE
Implement project tasks I and II scaffolding

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,3 @@
+# Copy this file to `.env` and replace placeholder values.
+FIFA_DB_URL=postgresql+psycopg2://username:password@localhost:5432/fifa
+YOUTUBE_API_KEY=your_youtube_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+__pycache__/
+*.pyc
+spark-warehouse/
+.metastore_db/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,131 @@
+# Course Project 1 – Tasks I & II Implementation
+
+This repository provides reference Python implementations for the first two tasks of the Course Project.
+It contains repeatable scripts that (1) build and populate the PostgreSQL data warehouse requested in
+Task I and (2) expose Apache Spark analytics required in Task II, including the YouTube comment
+publisher/subscriber workflow.
+
+## Repository Structure
+
+```text
+.
+├── Course_Project_1 (1).pdf      # Original project description
+├── README.md                     # This document
+├── requirements.txt              # Python dependencies
+├── data/
+│   ├── README.md                 # Dataset download instructions
+│   └── file_map.yml              # Expected CSV filenames per year
+└── src/
+    ├── __init__.py
+    ├── config.py                 # Configuration helpers
+    ├── db_utils.py               # PostgreSQL utilities and schema management
+    ├── task1_load.py             # Task I ingestion workflow
+    ├── task2_analytics.py        # Spark analytics for Task II
+    └── youtube_pubsub.py         # Publisher/subscriber utilities for Task II (Q5)
+```
+
+## Environment Setup
+
+1.  Install Python 3.10+ and Java 8/11 (required for PySpark).
+2.  Create and activate a virtual environment.
+3.  Install dependencies:
+
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+4.  Download the Kaggle dataset into the `data/` folder (see `data/README.md`).
+5.  Configure environment variables (see below) or copy `.env.template` to `.env` and fill values.
+
+### Required Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| `FIFA_DB_URL` | SQLAlchemy-compatible PostgreSQL connection string, e.g. `postgresql+psycopg2://user:pass@localhost:5432/fifa`. |
+| `YOUTUBE_API_KEY` | API key for the YouTube Data API v3 (required for Task II question 5). |
+
+## Task I – Build and Populate Tables
+
+Run the ingestion script after the dataset is placed under `data/`:
+
+```bash
+python -m src.task1_load --data-dir data
+```
+
+The script performs the following steps:
+
+1.  Loads the CSV filename mapping from `data/file_map.yml`.
+2.  Creates the `fifa` schema (if missing) and a unified `fifa.players` table with data types inferred from the CSV files.
+3.  Normalizes column headers across seasons, adds a `year` column, and inserts a `player_uid` synthetic key to guarantee uniqueness.
+4.  Uploads the consolidated dataframe into PostgreSQL using batch inserts.
+5.  Records ingestion metadata (row counts, years covered, and file hashes) in the `fifa.ingestion_log` table.
+
+The script is idempotent—it truncates the existing `fifa.players` table before loading so that re-runs start from a clean slate.
+
+### Dataset Features
+
+The unified `fifa.players` table stores the most relevant columns required by the project:
+
+* `player_uid` – synthetic unique identifier composed of gender, season, and `sofifa_id`.
+* `year` – season of the roster snapshot.
+* `gender` – `male` or `female` to distinguish the original roster.
+* `sofifa_id` – persistent player identifier from EA's FIFA database.
+* `short_name` / `long_name` – player display names used for reporting and YouTube matching.
+* `club_name`, `league_name` – organization attributes used for contract and age analytics.
+* `contract_valid_until` – contract expiration year, normalized as an integer for filtering.
+* `age`, `nationality_name` – demographic features needed for age ranking and nationality reports.
+* Additional skill attributes (`overall`, `potential`, `value_eur`, etc.) are preserved for future machine-learning tasks.
+
+### Why PostgreSQL instead of NoSQL?
+
+PostgreSQL remains the best default choice for this dataset. The yearly FIFA roster files share
+consistent tabular schemas and require strong typing, relational joins, and SQL analytics. Features
+like `contract_valid_until`, `club_name`, and `nationality_name` are naturally expressed as columns
+and benefit from indexing and declarative constraints. While a graph database such as Neo4J could
+model player relationships, it would add operational overhead without delivering clear advantages
+for the required aggregations (counts, averages, rankings). PostgreSQL also integrates seamlessly
+with Spark's JDBC connector, simplifying Task II.
+
+## Task II – Spark Analytics
+
+Spark-based analytics are implemented in `src/task2_analytics.py`. They can be executed either as Python functions (import the module) or through the CLI wrapper:
+
+```bash
+# Example invocations
+python -m src.task2_analytics contracts --year 2020 --top 5 --contract-year 2024
+python -m src.task2_analytics age --year 2018 --top 3 --order desc
+python -m src.task2_analytics nationality
+python -m src.task2_analytics histogram --output nationalities.png
+python -m src.task2_analytics youtube --limit 250 --dump-path data/youtube_comments.jsonl
+```
+
+### Available Analytics
+
+1.  **Contract Expirations** – `top_clubs_with_expiring_contracts`
+    * Returns the clubs with the highest number of players whose `contract_valid_until` year is at least the specified threshold.
+    * Results include ties for the last place when counts match.
+
+2.  **Average Age Ranking** – `rank_clubs_by_average_age`
+    * Calculates average age per club in the chosen season and supports ascending/descending order.
+    * Validates user inputs and preserves ties for the final rank.
+
+3.  **Most Popular Nationality per Year** – `most_popular_nationality_by_year`
+    * Produces a dictionary (or Spark dataframe) summarizing the most frequent nationality for each season.
+
+4.  **Nationality Histogram** – `nationality_histogram`
+    * Deduplicates players across seasons using their `sofifa_id` and plots the nationality distribution with Matplotlib. The histogram can be saved or displayed.
+
+5.  **YouTube Popularity Analysis** – `find_most_discussed_player`
+    * Uses the publisher/subscriber model in `youtube_pubsub.py` to collect comment streams from recent videos retrieved with the YouTube Data API.
+    * Aggregates mentions of `short_name` values from the 2022 roster and returns the player with the highest mention count. The raw comment dump is persisted for grading evidence.
+
+Each function automatically pulls data from PostgreSQL through Spark’s JDBC connector. Connection properties are reused from `FIFA_DB_URL`.
+
+## Explaining the Assignment
+
+The Course Project asks students to build an end-to-end data pipeline and analytical stack around the FIFA player dataset:
+
+* **Task I** focuses on data engineering—standardizing CSV files from multiple seasons, merging male and female rosters, creating a dedicated schema in PostgreSQL, and ensuring every row can be uniquely identified. The README must also discuss feature descriptions and whether a NoSQL option would be preferable. This repository supplies scripts and documentation to meet those requirements.
+* **Task II** moves to distributed analytics using Apache Spark. Students must implement parameterized queries for contract expiration trends, age-based club rankings, yearly nationality leaders, and deduplicated nationality histograms. Additionally, they must integrate external data (YouTube comments) using a publisher/subscriber pattern to determine the most discussed player for 2022.
+
+Combined, these deliverables demonstrate proficiency in database design, scalable ETL, distributed query processing, and streaming/text analytics, forming the foundation for later machine learning and deployment tasks.

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,8 @@
+# FIFA Dataset Setup
+
+Download the "FIFA 22 Complete Player Dataset" from Kaggle and extract the CSV files into this directory. The project expects the yearly player files named:
+
+- `players_15.csv` ... `players_22.csv` for the male rosters.
+- `female_players_16.csv` ... `female_players_22.csv` for the female rosters.
+
+If the dataset provides different filenames, update `data/file_map.yml` accordingly (see repository root for details).

--- a/data/file_map.yml
+++ b/data/file_map.yml
@@ -1,0 +1,17 @@
+male:
+  2015: players_15.csv
+  2016: players_16.csv
+  2017: players_17.csv
+  2018: players_18.csv
+  2019: players_19.csv
+  2020: players_20.csv
+  2021: players_21.csv
+  2022: players_22.csv
+female:
+  2016: female_players_16.csv
+  2017: female_players_17.csv
+  2018: female_players_18.csv
+  2019: female_players_19.csv
+  2020: female_players_20.csv
+  2021: female_players_21.csv
+  2022: female_players_22.csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+pandas>=2.0
+pyyaml>=6.0
+SQLAlchemy>=2.0
+psycopg2-binary>=2.9
+pyspark>=3.5
+python-dotenv>=1.0
+matplotlib>=3.8
+google-api-python-client>=2.130
+google-auth>=2.29
+google-auth-httplib2>=0.2

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Helper package for Course Project 1 tasks I and II."""

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Mapping
+
+import yaml
+from dotenv import load_dotenv
+
+
+@dataclass(frozen=True)
+class DatabaseConfig:
+    """Simple container for database connectivity information."""
+
+    url: str
+
+
+class ConfigError(RuntimeError):
+    """Raised when the local configuration is incomplete."""
+
+
+def load_environment(dotenv_path: str | os.PathLike[str] | None = None) -> None:
+    """Load environment variables from a `.env` file if present."""
+
+    load_dotenv(dotenv_path=dotenv_path, override=False)
+
+
+def get_database_config() -> DatabaseConfig:
+    """Return validated database configuration from the environment."""
+
+    load_environment()
+    url = os.getenv("FIFA_DB_URL")
+    if not url:
+        raise ConfigError(
+            "FIFA_DB_URL is not set. Export it or configure it in a .env file."
+        )
+    return DatabaseConfig(url=url)
+
+
+def load_file_map(data_dir: str | os.PathLike[str]) -> Mapping[str, Dict[int, str]]:
+    """Load the CSV filename map for male and female datasets."""
+
+    path = Path(data_dir) / "file_map.yml"
+    if not path.exists():
+        raise ConfigError(
+            f"Dataset mapping file not found at {path}. Please create it based on data/file_map.yml."
+        )
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    normalized: Dict[str, Dict[int, str]] = {}
+    for group, entries in data.items():
+        if not isinstance(entries, dict):
+            raise ConfigError(
+                f"Invalid mapping for '{group}'. Expected a dictionary of year -> filename."
+            )
+        normalized[group] = {}
+        for year_str, filename in entries.items():
+            year = int(year_str)
+            normalized[group][year] = filename
+    return normalized
+
+
+__all__ = [
+    "ConfigError",
+    "DatabaseConfig",
+    "get_database_config",
+    "load_file_map",
+    "load_environment",
+]

--- a/src/db_utils.py
+++ b/src/db_utils.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+import pandas as pd
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+SCHEMA_NAME = "fifa"
+PLAYERS_TABLE = "players"
+INGESTION_LOG_TABLE = "ingestion_log"
+
+
+def create_db_engine(url: str) -> Engine:
+    """Create a SQLAlchemy engine using the provided connection URL."""
+
+    return create_engine(url, future=True)
+
+
+def ensure_schema(engine: Engine) -> None:
+    """Create the target schema if it does not exist."""
+
+    with engine.begin() as conn:
+        conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{SCHEMA_NAME}"'))
+
+
+def write_players_table(engine: Engine, dataframe: pd.DataFrame) -> None:
+    """Replace the `fifa.players` table with the supplied dataframe."""
+
+    ensure_schema(engine)
+    dataframe.to_sql(
+        PLAYERS_TABLE,
+        engine,
+        schema=SCHEMA_NAME,
+        if_exists="replace",
+        index=False,
+        method="multi",
+        chunksize=1000,
+    )
+
+
+def ensure_ingestion_log(engine: Engine) -> None:
+    """Ensure the ingestion log table exists."""
+
+    ensure_schema(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                f"""
+                CREATE TABLE IF NOT EXISTS "{SCHEMA_NAME}"."{INGESTION_LOG_TABLE}" (
+                    ingestion_id SERIAL PRIMARY KEY,
+                    ingested_at TIMESTAMPTZ DEFAULT NOW(),
+                    row_count INTEGER NOT NULL,
+                    years INTEGER[] NOT NULL,
+                    source_files JSONB NOT NULL,
+                    checksum TEXT NOT NULL
+                )
+                """
+            )
+        )
+
+
+def log_ingestion(
+    engine: Engine,
+    *,
+    row_count: int,
+    years: list[int],
+    source_files: Dict[str, Dict[str, Any]],
+    checksum: str,
+) -> None:
+    """Insert a new ingestion record."""
+
+    ensure_ingestion_log(engine)
+    payload = {
+        "row_count": row_count,
+        "years": years,
+        "source_files": json.dumps(source_files),
+        "checksum": checksum,
+    }
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                f'INSERT INTO "{SCHEMA_NAME}"."{INGESTION_LOG_TABLE}" '
+                "(row_count, years, source_files, checksum) "
+                "VALUES (:row_count, :years, :source_files::jsonb, :checksum)"
+            ),
+            payload,
+        )
+
+
+__all__ = [
+    "SCHEMA_NAME",
+    "PLAYERS_TABLE",
+    "INGESTION_LOG_TABLE",
+    "create_db_engine",
+    "ensure_schema",
+    "write_players_table",
+    "log_ingestion",
+]

--- a/src/task1_load.py
+++ b/src/task1_load.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import pandas as pd
+
+from .config import ConfigError, get_database_config, load_file_map
+from .db_utils import create_db_engine, log_ingestion, write_players_table
+
+EXPECTED_COLUMNS = {
+    "sofifa_id",
+    "short_name",
+    "long_name",
+    "player_positions",
+    "age",
+    "height_cm",
+    "weight_kg",
+    "nationality_name",
+    "club_name",
+    "league_name",
+    "overall",
+    "potential",
+    "value_eur",
+    "wage_eur",
+    "release_clause_eur",
+    "contract_valid_until",
+}
+
+
+COLUMN_ALIASES = {
+    "nationality": "nationality_name",
+    "nationality_name": "nationality_name",
+    "team_jersey_number": "club_jersey_number",
+    "club": "club_name",
+    "club_contract_valid_until": "contract_valid_until",
+    "contract": "contract_valid_until",
+    "contract_end_year": "contract_valid_until",
+}
+
+
+def normalize_column(name: str) -> str:
+    """Convert column headers to snake_case."""
+
+    cleaned = name.strip().lower()
+    cleaned = cleaned.replace("%", "_pct").replace("/", "_")
+    cleaned = cleaned.replace("(", "_").replace(")", "")
+    cleaned = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in cleaned)
+    while "__" in cleaned:
+        cleaned = cleaned.replace("__", "_")
+    return cleaned.strip("_")
+
+
+def hash_file(path: Path, chunk_size: int = 65536) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_csv(path: Path) -> pd.DataFrame:
+    """Load a CSV file with pandas, preserving column types when possible."""
+
+    return pd.read_csv(path, low_memory=False)
+
+
+def standardize_dataframe(
+    frame: pd.DataFrame, *, year: int, gender: str
+) -> pd.DataFrame:
+    """Apply column normalization and add metadata fields."""
+
+    rename_map = {col: normalize_column(col) for col in frame.columns}
+    frame = frame.rename(columns=rename_map)
+    frame = frame.rename(columns=COLUMN_ALIASES)
+
+    if "nationality_name" not in frame.columns and "nationality" in frame.columns:
+        frame = frame.rename(columns={"nationality": "nationality_name"})
+
+    frame["year"] = year
+    frame["gender"] = gender
+
+    if "sofifa_id" not in frame.columns:
+        if "player_url" in frame.columns:
+            frame["sofifa_id"] = (
+                frame["player_url"].astype(str).str.extract(r"(\d+)", expand=False)
+            )
+        else:
+            raise ConfigError(
+                "Missing `sofifa_id` column and unable to infer it from player_url."
+            )
+    frame["sofifa_id"] = frame["sofifa_id"].astype("Int64")
+
+    if "short_name" not in frame.columns and "name" in frame.columns:
+        frame["short_name"] = frame["name"]
+
+    if "long_name" not in frame.columns and "full_name" in frame.columns:
+        frame["long_name"] = frame["full_name"]
+
+    if "contract_valid_until" in frame.columns:
+        frame["contract_valid_until"] = frame["contract_valid_until"].astype("Int64")
+    else:
+        frame["contract_valid_until"] = pd.NA
+
+    if "age" in frame.columns:
+        frame["age"] = frame["age"].astype("Int64")
+
+    frame["player_uid"] = (
+        frame["gender"].str[0].str.upper()
+        + "_"
+        + frame["year"].astype(str)
+        + "_"
+        + frame["sofifa_id"].astype(str)
+    )
+    frame = frame.drop_duplicates(subset=["player_uid"], keep="last")
+
+    # Ensure all expected columns exist
+    for column in EXPECTED_COLUMNS:
+        if column not in frame.columns:
+            frame[column] = pd.NA
+
+    ordered_columns = [
+        "player_uid",
+        "year",
+        "gender",
+        "sofifa_id",
+        "short_name",
+        "long_name",
+        "club_name",
+        "league_name",
+        "contract_valid_until",
+        "age",
+        "nationality_name",
+    ] + sorted(col for col in frame.columns if col not in {
+        "player_uid",
+        "year",
+        "gender",
+        "sofifa_id",
+        "short_name",
+        "long_name",
+        "club_name",
+        "league_name",
+        "contract_valid_until",
+        "age",
+        "nationality_name",
+    })
+    frame = frame[ordered_columns]
+    return frame.reset_index(drop=True)
+
+
+def load_players(data_dir: Path, file_map: Dict[str, Dict[int, str]]) -> Tuple[pd.DataFrame, Dict[str, Dict[str, str]]]:
+    """Read all configured CSV files and return a unified dataframe plus metadata."""
+
+    frames: list[pd.DataFrame] = []
+    metadata: Dict[str, Dict[str, str]] = {}
+
+    for group, entries in file_map.items():
+        gender = "female" if group.lower().startswith("f") else "male"
+        for year, filename in sorted(entries.items()):
+            csv_path = data_dir / filename
+            if not csv_path.exists():
+                raise FileNotFoundError(f"Expected dataset file not found: {csv_path}")
+            df = read_csv(csv_path)
+            frames.append(standardize_dataframe(df, year=year, gender=gender))
+            metadata.setdefault(str(year), {})[gender] = {
+                'file': filename,
+                'sha256': hash_file(csv_path),
+            }
+
+    unified = pd.concat(frames, axis=0, ignore_index=True)
+    unified = unified.sort_values(["year", "gender", "club_name", "short_name"])
+    return unified.reset_index(drop=True), metadata
+
+
+def compute_checksum(frame: pd.DataFrame) -> str:
+    """Compute a deterministic checksum for the dataframe content."""
+
+    payload = frame.sort_values("player_uid").to_json(orient="records", date_unit="s")
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Task I data ingestion pipeline")
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path("data"),
+        help="Directory containing the yearly CSV files",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    file_map = load_file_map(args.data_dir)
+    dataframe, metadata = load_players(args.data_dir, file_map)
+    checksum = compute_checksum(dataframe)
+
+    db_config = get_database_config()
+    engine = create_db_engine(db_config.url)
+    write_players_table(engine, dataframe)
+    log_ingestion(
+        engine,
+        row_count=len(dataframe),
+        years=sorted(dataframe["year"].unique().tolist()),
+        source_files=metadata,
+        checksum=checksum,
+    )
+
+    print("Ingestion completed successfully.")
+    print(json.dumps(
+        {
+            "rows_loaded": len(dataframe),
+            "years": sorted(dataframe["year"].unique().tolist()),
+            "checksum": checksum,
+        },
+        indent=2,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/task2_analytics.py
+++ b/src/task2_analytics.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+import os
+from typing import Dict, Iterable, Tuple
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from pyspark.sql import DataFrame, SparkSession, Window
+from pyspark.sql import functions as F
+from sqlalchemy.engine import make_url
+
+from .config import ConfigError, get_database_config
+from .db_utils import PLAYERS_TABLE, SCHEMA_NAME
+from .youtube_pubsub import CommentPublisher, CommentSubscriber
+
+SPARK_APP_NAME = "FifaAnalytics"
+POSTGRES_DRIVER = "org.postgresql.Driver"
+POSTGRES_JAR = "org.postgresql:postgresql:42.7.3"
+
+
+def build_spark_session(app_name: str = SPARK_APP_NAME) -> SparkSession:
+    """Create (or reuse) a Spark session configured for JDBC access."""
+
+    builder = SparkSession.builder.appName(app_name)
+    builder = builder.config("spark.jars.packages", POSTGRES_JAR)
+    return builder.getOrCreate()
+
+
+def load_players_frame(spark: SparkSession) -> DataFrame:
+    """Load the unified players table from PostgreSQL via JDBC."""
+
+    db_config = get_database_config()
+    url = make_url(db_config.url)
+    if url.drivername.split("+")[0] != "postgresql":
+        raise ConfigError("Only PostgreSQL connection URLs are supported.")
+
+    host = url.host or "localhost"
+    port = url.port or 5432
+    database = url.database
+    if not database:
+        raise ConfigError("Database name missing from FIFA_DB_URL.")
+
+    jdbc_url = f"jdbc:postgresql://{host}:{port}/{database}"
+    properties = {
+        "user": url.username or "",
+        "password": url.password or "",
+        "driver": POSTGRES_DRIVER,
+        "currentSchema": SCHEMA_NAME,
+    }
+    return spark.read.format("jdbc").options(
+        url=jdbc_url,
+        dbtable=f'"{SCHEMA_NAME}"."{PLAYERS_TABLE}"',
+    ).options(**properties).load()
+
+
+def top_clubs_with_expiring_contracts(
+    frame: DataFrame, *, year: int, top: int, contract_year: int
+) -> DataFrame:
+    if top < 1:
+        raise ValueError("`top` must be a positive integer")
+
+    filtered = frame.filter(
+        (F.col("year") == year) & (F.col("contract_valid_until") >= contract_year)
+    )
+    grouped = (
+        filtered.groupBy("club_name")
+        .agg(F.count("*").alias("player_count"))
+        .filter(F.col("player_count") > 0)
+    )
+    window = Window.orderBy(F.col("player_count").desc(), F.col("club_name"))
+    ranked = grouped.withColumn("rank", F.dense_rank().over(window))
+    return ranked.filter(F.col("rank") <= top).orderBy("rank", F.col("club_name"))
+
+
+def rank_clubs_by_average_age(
+    frame: DataFrame, *, year: int, top: int, order: str = "desc"
+) -> DataFrame:
+    if top < 1:
+        raise ValueError("`top` must be a positive integer")
+    direction = order.lower()
+    if direction not in {"asc", "desc"}:
+        raise ValueError("order must be either 'asc' or 'desc'")
+
+    filtered = frame.filter((F.col("year") == year) & F.col("age").isNotNull())
+    grouped = filtered.groupBy("club_name").agg(F.avg("age").alias("average_age"))
+    window = Window.orderBy(
+        F.col("average_age").asc() if direction == "asc" else F.col("average_age").desc(),
+        F.col("club_name"),
+    )
+    ranked = grouped.withColumn("rank", F.dense_rank().over(window))
+    ordering = ["rank", F.col("club_name")]
+    return ranked.filter(F.col("rank") <= top).orderBy(*ordering)
+
+
+def most_popular_nationality_by_year(frame: DataFrame) -> DataFrame:
+    aggregated = (
+        frame.groupBy("year", "nationality_name")
+        .agg(F.count("*").alias("player_count"))
+    )
+    window = Window.partitionBy("year").orderBy(F.col("player_count").desc())
+    ranked = aggregated.withColumn("rank", F.row_number().over(window))
+    return ranked.filter(F.col("rank") == 1).orderBy("year")
+
+
+def nationality_histogram(
+    frame: DataFrame, *, output_path: str | None = None
+) -> Dict[str, int]:
+    unique_players = frame.dropna(subset=["sofifa_id"]).dropDuplicates(["sofifa_id"])
+    histogram = (
+        unique_players.groupBy("nationality_name")
+        .agg(F.count("*").alias("player_count"))
+        .orderBy(F.col("player_count").desc())
+    )
+    pdf = histogram.toPandas()
+    plt.figure(figsize=(12, 6))
+    plt.bar(pdf["nationality_name"], pdf["player_count"])
+    plt.xticks(rotation=90)
+    plt.ylabel("Players (deduplicated)")
+    plt.title("Unique players per nationality")
+    plt.tight_layout()
+    if output_path:
+        plt.savefig(output_path, dpi=200)
+    else:
+        plt.show()
+    return dict(zip(pdf["nationality_name"], pdf["player_count"]))
+
+
+def build_alias_map(frame: DataFrame) -> Dict[str, str]:
+    """Prepare a mapping of aliases to canonical player names."""
+
+    rows = frame.select("short_name", "long_name").dropna(subset=["short_name"]).collect()
+    alias_map: Dict[str, str] = {}
+    for row in rows:
+        canonical = row["short_name"].strip()
+        alias_map[canonical.lower()] = canonical
+        long_name = row["long_name"]
+        if long_name and long_name.strip():
+            alias_map[long_name.lower()] = canonical
+    return alias_map
+
+
+def find_most_discussed_player(
+    frame: DataFrame,
+    *,
+    api_key: str,
+    limit: int = 500,
+    dump_path: str | None = None,
+) -> Tuple[str, Counter]:
+    roster_2022 = frame.filter((F.col("year") == 2022) & (F.col("gender") == "male"))
+    alias_map = build_alias_map(roster_2022)
+    if not alias_map:
+        raise RuntimeError("No players found for 2022 male roster.")
+
+    publisher = CommentPublisher(api_key=api_key)
+    subscriber = CommentSubscriber(alias_map=alias_map, dump_path=dump_path)
+    counts = subscriber.process(publisher.iter_comments(limit=limit))
+    if not counts:
+        raise RuntimeError("No player mentions detected in the sampled comments.")
+    top_player, _ = counts.most_common(1)[0]
+    return top_player, counts
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Task II Spark analytics")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    contracts = subparsers.add_parser("contracts", help="Top clubs with expiring contracts")
+    contracts.add_argument("--year", type=int, required=True)
+    contracts.add_argument("--top", type=int, required=True)
+    contracts.add_argument("--contract-year", type=int, required=True)
+
+    age = subparsers.add_parser("age", help="Rank clubs by average age")
+    age.add_argument("--year", type=int, required=True)
+    age.add_argument("--top", type=int, required=True)
+    age.add_argument("--order", type=str, default="desc")
+
+    nationality = subparsers.add_parser(
+        "nationality", help="Most popular nationality per year"
+    )
+
+    histogram = subparsers.add_parser(
+        "histogram", help="Generate nationality histogram"
+    )
+    histogram.add_argument("--output", type=str, default=None)
+
+    youtube = subparsers.add_parser(
+        "youtube", help="Find the most discussed player on YouTube"
+    )
+    youtube.add_argument("--limit", type=int, default=500)
+    youtube.add_argument("--dump-path", type=str, default=None)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    spark = build_spark_session()
+    frame = load_players_frame(spark)
+
+    if args.command == "contracts":
+        result = top_clubs_with_expiring_contracts(
+            frame, year=args.year, top=args.top, contract_year=args.contract_year
+        )
+        result.show(truncate=False)
+    elif args.command == "age":
+        result = rank_clubs_by_average_age(
+            frame, year=args.year, top=args.top, order=args.order
+        )
+        result.show(truncate=False)
+    elif args.command == "nationality":
+        result = most_popular_nationality_by_year(frame)
+        result.show(truncate=False)
+    elif args.command == "histogram":
+        histogram_data = nationality_histogram(frame, output_path=args.output)
+        print(json.dumps(histogram_data, indent=2))
+    elif args.command == "youtube":
+        from .config import load_environment
+
+        load_environment()
+        api_key = os.getenv('YOUTUBE_API_KEY')
+        if not api_key:
+            raise ConfigError('YOUTUBE_API_KEY is not configured.')
+        top_player, counts = find_most_discussed_player(
+            frame, api_key=api_key, limit=args.limit, dump_path=args.dump_path
+        )
+        summary = {
+            'player': top_player,
+            'mentions': counts[top_player],
+            'counts': dict(counts),
+        }
+        print(json.dumps(summary, indent=2))
+    else:
+        raise ValueError(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/youtube_pubsub.py
+++ b/src/youtube_pubsub.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections import Counter
+from contextlib import ExitStack
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Optional
+
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_SEARCH_TERMS = [
+    "fifa world cup",
+    "soccer",
+    "football",
+    "fifa",
+]
+
+
+@dataclass
+class Comment:
+    """Representation of a YouTube comment."""
+
+    video_id: str
+    comment_id: str
+    author: str
+    text: str
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__, ensure_ascii=False)
+
+
+class CommentPublisher:
+    """Fetch comments from YouTube and publish them to subscribers."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        search_terms: Optional[Iterable[str]] = None,
+        max_results_per_term: int = 25,
+    ) -> None:
+        self.api_key = api_key
+        self.search_terms = list(search_terms or DEFAULT_SEARCH_TERMS)
+        self.max_results_per_term = max_results_per_term
+        self.youtube = build("youtube", "v3", developerKey=api_key, cache_discovery=False)
+
+    def iter_video_ids(self) -> Iterator[str]:
+        seen: set[str] = set()
+        for term in self.search_terms:
+            try:
+                request = self.youtube.search().list(
+                    q=term,
+                    part="id",
+                    type="video",
+                    maxResults=min(self.max_results_per_term, 50),
+                    order="date",
+                    relevanceLanguage="en",
+                )
+                response = request.execute()
+            except HttpError as exc:
+                LOGGER.warning("YouTube search failed for term '%s': %s", term, exc)
+                continue
+            for item in response.get("items", []):
+                video_id = item.get("id", {}).get("videoId")
+                if video_id and video_id not in seen:
+                    seen.add(video_id)
+                    yield video_id
+
+    def iter_comments(self, limit: Optional[int] = None) -> Iterator[Comment]:
+        total = 0
+        for video_id in self.iter_video_ids():
+            page_token: Optional[str] = None
+            while True:
+                try:
+                    request = self.youtube.commentThreads().list(
+                        part="snippet",
+                        videoId=video_id,
+                        maxResults=100,
+                        pageToken=page_token,
+                        textFormat="plainText",
+                        order="relevance",
+                    )
+                    response = request.execute()
+                except HttpError as exc:
+                    LOGGER.warning("Failed to fetch comments for %s: %s", video_id, exc)
+                    break
+
+                for item in response.get("items", []):
+                    snippet = item.get("snippet", {}).get("topLevelComment", {}).get("snippet", {})
+                    comment = Comment(
+                        video_id=video_id,
+                        comment_id=item.get("id", ""),
+                        author=snippet.get("authorDisplayName", "unknown"),
+                        text=snippet.get("textDisplay", ""),
+                    )
+                    yield comment
+                    total += 1
+                    if limit is not None and total >= limit:
+                        return
+
+                page_token = response.get("nextPageToken")
+                if not page_token:
+                    break
+
+
+class CommentSubscriber:
+    """Consume comments and count mentions of player aliases."""
+
+    def __init__(
+        self,
+        *,
+        alias_map: Dict[str, str],
+        dump_path: Optional[str] = None,
+    ) -> None:
+        self.alias_map = {
+            alias.lower(): canonical for alias, canonical in alias_map.items()
+        }
+        self.patterns: Dict[str, re.Pattern[str]] = {
+            alias: re.compile(rf"\b{re.escape(alias)}\b", re.IGNORECASE)
+            for alias in self.alias_map
+        }
+        self.dump_path = Path(dump_path) if dump_path else None
+
+    def process(self, comments: Iterable[Comment]) -> Counter:
+        counts: Counter = Counter()
+        with ExitStack() as stack:
+            handle = (
+                stack.enter_context(self.dump_path.open("w", encoding="utf-8"))
+                if self.dump_path
+                else None
+            )
+            for comment in comments:
+                if handle:
+                    handle.write(comment.to_json() + "\n")
+                text = comment.text.lower()
+                for alias, pattern in self.patterns.items():
+                    if pattern.search(text):
+                        canonical = self.alias_map[alias]
+                        counts[canonical] += 1
+        return counts
+
+
+__all__ = [
+    "Comment",
+    "CommentPublisher",
+    "CommentSubscriber",
+]


### PR DESCRIPTION
## Summary
- add README guidance, dataset mapping, and environment templates for course project tasks I and II
- implement PostgreSQL ingestion pipeline that standardizes yearly FIFA CSVs and records ingestion metadata
- provide Spark analytics module and YouTube comment publisher/subscriber workflow covering all Task II questions

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dc0e3aea9c83249c1597dd4e639e1e